### PR TITLE
Add zstd compressed kernel support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,9 +4,10 @@ project('unzboot', 'c',
 
 glibdep = dependency('glib-2.0')
 zdep = dependency('zlib')
+zstddep = dependency('libzstd')
 
 exe = executable('unzboot', 'unzboot.c',
-  dependencies: [glibdep, zdep],
+  dependencies: [glibdep, zdep, zstddep],
   install : true)
 
 test('basic', exe)


### PR DESCRIPTION
Some kernels may choose zstd for compression and used to report "zstd22"[1], and now "zstd"[2] in the 32-char field for the zImage header. Only "gzip" and "zstd" are passed since
    0b2c29fb68f8 ("efi/zboot: Limit compression options to GZIP and ZSTD")

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0b2c29fb68f8bf3e87a9d88404aa6fdd486223e5
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/firmware/efi/libstub/Makefile.zboot#n18